### PR TITLE
[TECHNICAL-SUPPORT] LPS-79943

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -2428,14 +2428,14 @@ public class CalendarBookingLocalServiceImpl
 
 		List<NotificationRecipient> notificationRecipients = new ArrayList<>();
 
+		if (calendarBooking.isMasterBooking()) {
+			return notificationRecipients;
+		}
+
 		CalendarResource calendarResource =
 			calendarBooking.getCalendarResource();
 
 		Set<User> users = new HashSet<>();
-
-		if (calendarBooking.isMasterBooking()) {
-			users.add(userLocalService.fetchUser(calendarBooking.getUserId()));
-		}
 
 		users.add(userLocalService.fetchUser(calendarResource.getUserId()));
 


### PR DESCRIPTION
@jeyvison,

For this fix I tried emulating the behavior that Google calendar follows in that no notifications are sent for the master booking.

The core of the issue is that if the calendar booking creator is also invited to the event, that user has two calendar booking objects attached to them: one as a child calendar booking and one as the master booking. With this change, the child calendar booking notification will still be sent but the master one will no longer be sent so the user only receives one email notification for their personal calendar.

Please let me know your thoughts on this as there are a number of ways to resolve this issue but this seemed the most straight forward.