### PR TITLE
LPS-81887 Message key "Pending" for calendar portlet should be differ…

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -399,7 +399,7 @@ while (manageableCalendarsIterator.hasNext()) {
 					<aui:row cssClass="calendar-booking-invitations">
 						<aui:col width="<%= (calendarBooking != null) ? 25 : 33 %>">
 							<label class="field-label">
-								<liferay-ui:message key="pending" /> (<span id="<portlet:namespace />pendingCounter"><%= pendingCalendarsJSONArray.length() %></span>)
+								<liferay-ui:message key="pending-calendar" /> (<span id="<portlet:namespace />pendingCounter"><%= pendingCalendarsJSONArray.length() %></span>)
 							</label>
 
 							<div class="calendar-portlet-calendar-list" id="<portlet:namespace />calendarListPending"></div>

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language.properties
@@ -140,6 +140,7 @@ october=October
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change.
 only-this-instance=Only This Instance
 other-calendars=Other Calendars
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code.
 position.first=First
 position.fourth=Fourth

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ar.properties
@@ -140,6 +140,7 @@ october=تشرين الأول/أكتوبر (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=وسيتم تعديل هذا الحدث فقط. لن يتم تغيير بقية السلسلة. (Automatic Translation)
 only-this-instance=فقط من هذا المثيل (Automatic Translation)
 other-calendars=تقويمات أخرى (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=الرجاء إدخال رمز مورد فريد. (Automatic Translation)
 position.first=الأولى (Automatic Translation)
 position.fourth=الرابعة (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_bg.properties
@@ -140,6 +140,7 @@ october=Октомври (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Само това събитие ще бъдат променени. Останалата част от поредицата няма да се промени. (Automatic Translation)
 only-this-instance=Само този случай (Automatic Translation)
 other-calendars=Други календари (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Моля въведете код на уникален ресурс. (Automatic Translation)
 position.first=Първо (Automatic Translation)
 position.fourth=Четвърти (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ca.properties
@@ -140,6 +140,7 @@ october=Octubre
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Només es modificarà aquest esdeveniment. La resta de la sèrie no canviarà.
 only-this-instance=Només aquesta instància
 other-calendars=Altres Calendaris
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Si us plau, introduïu un codi de recurs únic.
 position.first=Primer
 position.fourth=Quart

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_cs.properties
@@ -140,6 +140,7 @@ october=Říjen (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Pouze tato událost bude změněna. Zbytek série nezmění. (Automatic Translation)
 only-this-instance=Pouze tato instance
 other-calendars=Ostatní kalendáře
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Prosím, zadejte jedinečný zdrojový kód.
 position.first=První (Automatic Translation)
 position.fourth=Čtvrtá (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_da.properties
@@ -140,6 +140,7 @@ october=Oktober (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Other Calendars (Automatic Copy)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code. (Automatic Copy)
 position.first=Første (Automatic Translation)
 position.fourth=Fjerde (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_de.properties
@@ -140,6 +140,7 @@ october=Oktober
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Es wird nur dieser Termin geändert. Die übrige Serie ist nicht betroffen.
 only-this-instance=Nur dieser Termin
 other-calendars=Andere Kalender
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Bitte geben Sie einen eindeutigen Ressourcecode ein.
 position.first=Ersten
 position.fourth=Vierte

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_el.properties
@@ -140,6 +140,7 @@ october=Οκτωβρίου (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Μόνο αυτό το γεγονός θα πρέπει να τροποποιηθεί. Τα υπόλοιπα της σειράς δεν θα αλλάξει. (Automatic Translation)
 only-this-instance=Μόνο αυτήν την εμφάνιση (Automatic Translation)
 other-calendars=Άλλα ημερολόγια (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Παρακαλούμε εισάγετε ένα μοναδικό πόρο κώδικα. (Automatic Translation)
 position.first=Πρώτη (Automatic Translation)
 position.fourth=Τέταρτη (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_en.properties
@@ -140,6 +140,7 @@ october=October
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change.
 only-this-instance=Only This Instance
 other-calendars=Other Calendars
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code.
 position.first=First
 position.fourth=Fourth

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_es.properties
@@ -140,6 +140,7 @@ october=Octubre
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Solo se modificará este evento. El resto de la serie no cambiará.
 only-this-instance=Solo esta ocurrencia
 other-calendars=Otros calendarios
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Por favor, indique un código de recurso único.
 position.first=Primero
 position.fourth=Cuarto

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_et.properties
@@ -140,6 +140,7 @@ october=Oktoober (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Vaid sel juhul muudetakse. Ülejäänud seeria ei muutu. (Automatic Translation)
 only-this-instance=Ainult sel juhul (Automatic Translation)
 other-calendars=Muud kalendrid (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Sisestage kordumatu ressursi tähise. (Automatic Translation)
 position.first=Esimese (Automatic Translation)
 position.fourth=Neljas (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_eu.properties
@@ -140,6 +140,7 @@ october=October (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Beste Egutegiak
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Mesedez, sartu baliabide kode bakarra.
 position.first=First (Automatic Copy)
 position.fourth=Fourth (Automatic Copy)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_fa.properties
@@ -140,6 +140,7 @@ october=اکتبر
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=تنها این رویداد تغییر می کند. بقیه این سری تغییر نخواهد کرد. (Automatic Translation)
 only-this-instance=فقط این مورد
 other-calendars=سایر تقویم‌ها
+pending-calendar=Pending
 please-enter-a-unique-resource-code=لطفا یک کد منبع یکتا وارد نمایید.
 position.first=اولین
 position.fourth=چهارمین

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_fi.properties
@@ -140,6 +140,7 @@ october=Lokakuu
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Vain tätä tapahtumaa muutetaan. Muut sarjassa eivät muutu.
 only-this-instance=Vain tässä ilmentymässä
 other-calendars=Muut kalenterit
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Syötä yksilöivä resurssikoodi.
 position.first=Ensimmäinen
 position.fourth=Neljäs

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_fr.properties
@@ -140,6 +140,7 @@ october=Octobre
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Seul cet événement sera modifié. Le reste des séries resteront inchangées.
 only-this-instance=Seule cette instance
 other-calendars=Autres calendriers
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Merci de saisir un code de ressource unique.
 position.first=Premier
 position.fourth=Quatrième

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_gl.properties
@@ -140,6 +140,7 @@ october=October (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Outros calendarios
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Por favor, escribe un único código de recurso.
 position.first=First (Automatic Copy)
 position.fourth=Fourth (Automatic Copy)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_hi_IN.properties
@@ -140,6 +140,7 @@ october=अक्टूबर (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=इस घटना के केवल संशोधित किया जाएगा। श्रृंखला के बाकी नहीं बदलेगा। (Automatic Translation)
 only-this-instance=केवल इस आवृत्ति (Automatic Translation)
 other-calendars=अन्य कैलेंडर (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=कृपया एक बेजोड़ संसाधन कोड दर्ज करें। (Automatic Translation)
 position.first=प्रथम (Automatic Translation)
 position.fourth=चौथे (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_hr.properties
@@ -140,6 +140,7 @@ october=October (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Other Calendars (Automatic Copy)
+pending=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code. (Automatic Copy)
 position.first=First (Automatic Copy)
 position.fourth=Fourth (Automatic Copy)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_hu.properties
@@ -140,6 +140,7 @@ october=Október
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Csak ez az esemény lesz módosítva. A sorozat többi tagja nem változik.
 only-this-instance=Csak ebben az esetben
 other-calendars=Más naptárak
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Kérlek, adj meg egy egyedi erőforrás kódot.
 position.first=Első
 position.fourth=Negyedik

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_in.properties
@@ -140,6 +140,7 @@ october=Oktober (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Hanya peristiwa ini akan dimodifikasi. Sisa seri tidak akan berubah. (Automatic Translation)
 only-this-instance=Hanya contoh ini (Automatic Translation)
 other-calendars=Kalender Lainnya
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Masukan sumber kode yang unik.
 position.first=Pertama (Automatic Translation)
 position.fourth=Keempat (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_it.properties
@@ -140,6 +140,7 @@ october=Ottobre
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Verrà modificato solo questo evento. Il resto della serie non cambierà.
 only-this-instance=Solo quest'Istanza
 other-calendars=Altri Calendari
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Inserisci un codice risorsa univoco.
 position.first=Primo
 position.fourth=Quarto

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_iw.properties
@@ -140,6 +140,7 @@ october=אוקטובר
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=רק האירוע הזה ישונה. שאר הסדרה לא תשתנה.
 only-this-instance=המופע הזה בלבד
 other-calendars=לוחות שנה אחרים
+pending-calendar=Pending
 please-enter-a-unique-resource-code=אנא הזן קוד משאב ייחודי.
 position.first=ראשון
 position.fourth=רביעי

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ja.properties
@@ -140,6 +140,7 @@ october=10月
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=このイベントのみを変更します。今後の繰り返しイベントは変更されません。
 only-this-instance=このインスタンスのみ
 other-calendars=他のカレンダー
+pending-calendar=返答待ち
 please-enter-a-unique-resource-code=重複しないリソースコードを入力してください
 position.first=第一
 position.fourth=第四

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ko.properties
@@ -140,6 +140,7 @@ october=10 월 (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=이 이벤트에만 수정 됩니다. 시리즈의 나머지 변경 되지 않습니다. (Automatic Translation)
 only-this-instance=만이 인스턴스 (Automatic Translation)
 other-calendars=다른 달력 (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=고유 리소스 코드를 입력 하십시오. (Automatic Translation)
 position.first=첫 번째 (Automatic Translation)
 position.fourth=4 (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_lo.properties
@@ -140,6 +140,7 @@ october=October (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Other Calendars (Automatic Copy)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code. (Automatic Copy)
 position.first=First (Automatic Copy)
 position.fourth=Fourth (Automatic Copy)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_lt.properties
@@ -140,6 +140,7 @@ october=Spalio (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Tik šį įvykį bus pakeistas. Likusi serijos nesikeis. (Automatic Translation)
 only-this-instance=Tik šiuo atveju (Automatic Translation)
 other-calendars=Kiti vadovai (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Prašome įvesti kodą, ávairovë. (Automatic Translation)
 position.first=Pirmosios (Automatic Translation)
 position.fourth=Ketvirtoji (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_nb.properties
@@ -140,6 +140,7 @@ october=Oktober
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Bare denne hendelsen vil bli endret. Resten av serien endres ikke. (Automatic Translation)
 only-this-instance=Bare denne instansen
 other-calendars=Andre kalendre
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Vennligst angi en unik ressurskode.
 position.first=Første
 position.fourth=Fjerde

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_nl.properties
@@ -140,6 +140,7 @@ october=Oktober
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Alleen deze gebeurtenis wordt gewijzigd. De rest van de reeks zal niet veranderen.
 only-this-instance=Alleen deze instance
 other-calendars=Andere kalenders
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Voer een unieke resourcecode in.
 position.first=Eerst
 position.fourth=Vierde

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_nl_BE.properties
@@ -140,6 +140,7 @@ october=Oktober (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Alleen dit exemplaar (Automatic Translation)
 other-calendars=Andere agenda 's (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Voer een unieke bron code. (Automatic Translation)
 position.first=Eerste (Automatic Translation)
 position.fourth=Vierde (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_pl.properties
@@ -140,6 +140,7 @@ october=Października (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Tylko tego zdarzenia zostaną zmodyfikowane. Pozostałej części tej serii nie zmieni się. (Automatic Translation)
 only-this-instance=Tylko w tej instancji
 other-calendars=Pozostałe kalendarze
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Wprowadź unikalny kod zasobu.
 position.first=Pierwsze (Automatic Translation)
 position.fourth=Czwarty (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_pt_BR.properties
@@ -140,6 +140,7 @@ october=Outubro
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Apenas este evento será modificado. O resto da série não será alterada.
 only-this-instance=Apenas esta instância
 other-calendars=Outros calendários
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Por favor entre um código único para o recurso.
 position.first=Primeiro
 position.fourth=Quarto

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_pt_PT.properties
@@ -140,6 +140,7 @@ october=Outubro
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Somente este evento será modificado. O resto da série não vai mudar. (Automatic Translation)
 only-this-instance=Apenas esta instância
 other-calendars=Outros Calendários
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Por favor indique um código de recurso único.
 position.first=Primeiro
 position.fourth=Quarto

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ro.properties
@@ -140,6 +140,7 @@ october=Octombrie (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Numai acest eveniment va fi modificat. Restul de serie nu se va schimba. (Automatic Translation)
 only-this-instance=Numai în acest caz (Automatic Translation)
 other-calendars=Alte calendare (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Vă rugăm să introduceţi un cod unic de resurse. (Automatic Translation)
 position.first=Prima (Automatic Translation)
 position.fourth=A patra (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_ru.properties
@@ -140,6 +140,7 @@ october=Октябрь (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Только это событие будет изменен. Остальной части этой серии не изменится. (Automatic Translation)
 only-this-instance=Только этот экземпляр
 other-calendars=Другие календари
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Пожалуйста, введите уникальный код ресурса.
 position.first=Первый (Automatic Translation)
 position.fourth=Четвертый (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sk.properties
@@ -140,6 +140,7 @@ october=Október
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Len v tomto prípade sa upraví. Zvyšok série sa nezmení. (Automatic Translation)
 only-this-instance=Iba táto inštancia
 other-calendars=Iné kalendáre
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Zadajte prosím unikátny kód zdroja.
 position.first=Prvý
 position.fourth=Štvrtý

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sl.properties
@@ -140,6 +140,7 @@ october=Oktobra (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Bo treba spremeniti le ta dogodek. Preostanek serije ne bo spremenilo. (Automatic Translation)
 only-this-instance=Samo v tem primeru (Automatic Translation)
 other-calendars=Drugi koledarji (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Vnesite šifro edinstven vir. (Automatic Translation)
 position.first=Prvi (Automatic Translation)
 position.fourth=Četrti (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sr_RS.properties
@@ -140,6 +140,7 @@ october=October (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Other Calendars (Automatic Copy)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code. (Automatic Copy)
 position.first=First (Automatic Copy)
 position.fourth=Fourth (Automatic Copy)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -140,6 +140,7 @@ october=October (Automatic Copy)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Other Calendars (Automatic Copy)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code. (Automatic Copy)
 position.first=First (Automatic Copy)
 position.fourth=Fourth (Automatic Copy)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_sv.properties
@@ -140,6 +140,7 @@ october=Oktober (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Only this event will be modified. The rest of the series will not change. (Automatic Copy)
 only-this-instance=Only This Instance (Automatic Copy)
 other-calendars=Other Calendars (Automatic Copy)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Please enter a unique resource code. (Automatic Copy)
 position.first=Första (Automatic Translation)
 position.fourth=Fjärde (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_th.properties
@@ -140,6 +140,7 @@ october=ตุลาคม (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=เหตุการณ์นี้จะแก้ไข ส่วนเหลือของชุดจะไม่มีการเปลี่ยนแปลง (Automatic Translation)
 only-this-instance=อินสแตนซ์นี้ (Automatic Translation)
 other-calendars=ปฏิทินอื่น ๆ (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=โปรดป้อนรหัสเฉพาะของทรัพยากร (Automatic Translation)
 position.first=ครั้งแรก (Automatic Translation)
 position.fourth=สี่ (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_tr.properties
@@ -140,6 +140,7 @@ october=Ekim (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Sadece bu olay değiştirilecek. Serinin geri kalanı değişmez. (Automatic Translation)
 only-this-instance=Yalnızca bu örnek (Automatic Translation)
 other-calendars=Diğer takvimler (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Benzersiz kaynak kodunu giriniz. (Automatic Translation)
 position.first=İlk (Automatic Translation)
 position.fourth=Dördüncü (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_uk.properties
@@ -140,6 +140,7 @@ october=Жовтень (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Тільки ця подія буде змінено. Інші серії не зміниться. (Automatic Translation)
 only-this-instance=Лише цей екземпляр (Automatic Translation)
 other-calendars=Інші календарі (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Будь ласка, введіть код унікальний ресурс. (Automatic Translation)
 position.first=Перший (Automatic Translation)
 position.fourth=Четвертий (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_vi.properties
@@ -140,6 +140,7 @@ october=Tháng mười (Automatic Translation)
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=Chỉ sự kiện này sẽ được thay đổi. Phần còn lại của bộ phim sẽ không thay đổi. (Automatic Translation)
 only-this-instance=Chỉ trong trường hợp (Automatic Translation)
 other-calendars=Lịch khác (Automatic Translation)
+pending-calendar=Pending
 please-enter-a-unique-resource-code=Vui lòng nhập một mã nguồn duy nhất. (Automatic Translation)
 position.first=Đầu tiên (Automatic Translation)
 position.fourth=Thứ tư (Automatic Translation)

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_zh_CN.properties
@@ -140,6 +140,7 @@ october=十月
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=只有此活动将被更改。整个系列的其他部分将不会改变。
 only-this-instance=只有此实例
 other-calendars=其他日历
+pending-calendar=Pending
 please-enter-a-unique-resource-code=请输入独一无二的源代码。
 position.first=第一个
 position.fourth=第四个

--- a/modules/apps/calendar/calendar-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/calendar/calendar-web/src/main/resources/content/Language_zh_TW.properties
@@ -140,6 +140,7 @@ october=十月
 only-this-event-will-be-modified-the-rest-of-the-series-will-not-change=僅此事件將被修改。系列的其餘部分不會改變。 (Automatic Translation)
 only-this-instance=只有這實體
 other-calendars=其他行事曆
+pending-calendar=Pending
 please-enter-a-unique-resource-code=請輸入唯一的資源碼。
 position.first=第一
 position.fourth=第四


### PR DESCRIPTION
Hi Adam, I'm Yasu, a supportability engineer based in Japan. I heard you are a team lead of Calendar so I sent PR to you here. I'm currently working on translations for 7.1 release and found a message shared in multiple locations in code need to be separated because meaning of Japanese are different depending on the context.