### PR TITLE
[TECHNICAL-SUPPORT] LPS-81851

### DIFF
--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -161,11 +161,9 @@
 				Layout controlPanelLayout = themeDisplay.getControlPanelLayout();
 				%>
 
-				<c:if test="<%= controlPanelLayout.getGroupId() != scopeGroup.getGroupId() %>">
-					getLayoutRelativeControlPanelURL: function() {
-						return '<%= PortalUtil.getLayoutRelativeURL(new VirtualLayout(controlPanelLayout, scopeGroup), themeDisplay) %>';
-					},
-				</c:if>
+				getLayoutRelativeControlPanelURL: function() {
+					return '<%= PortalUtil.getLayoutRelativeURL(new VirtualLayout(controlPanelLayout, scopeGroup), themeDisplay) %>';
+				},
 
 				getLayoutRelativeURL: function() {
 					return '<%= PortalUtil.getLayoutRelativeURL(layout, themeDisplay) %>';


### PR DESCRIPTION
From @brianikim

>Hello @gregory-bretall
>
>https://issues.liferay.com/browse/LPS-81851
>
>The issure here is that the Select Button for a Documents and Media Field in Kaleo Workflow Forms does not work because of the console error:
>
>TypeError: themeDisplay.getLayoutRelativeControlPanelURL is not a function[Learn More]
>
>The reason this issue occurs is because in https://issues.liferay.com/browse/LPS-73479, the following condition was introduced https://github.com/liferay/liferay-portal/blob/8fe6936c72cfc0e3370095e3eadd71d1482bf624/portal-web/docroot/html/common/themes/top_js.jspf#L164-L168 in which getLayoutRelativeControlPanelURL is only ran if the id of the scopeGroup is not equal to the id of the ControlPanelLayout.
>
>Because both the ControlPanelLayout id and scopeGroup id is the same, in this case, the method will not be executed. Therefore, the simple fix is to remove the condition check because it is unnecessary as the change introduced by LPS-73479 also made changes in this commit liferay/liferay-portal@3930b59 which ensures that getLayoutRelativeControlPanelURL will be used no matter what.
>
>Please let me know if you have any questions. Thanks.
>
>Edit: You can reproduce this issue either by using the workaround given in LPS-81851 or after pulling the commit from https://issues.liferay.com/browse/LPS-81845.
>
>Sincerely,
Brian Kim