### PR TITLE
LPS-83662 Adjust confirmation question in test macro

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Role.macro
@@ -1052,7 +1052,7 @@
 					<var name="menuItem" value="Delete" />
 				</execute>
 
-				<execute function="Confirm" value1="Are you sure you want to delete this? It will be deleted immediately." />
+				<execute function="Confirm" value1="Are you sure you want to delete this role? If it is a reviewer role, it's task assignments will be deleted along with it." />
 			</then>
 		</while>
 	</command>


### PR DESCRIPTION
Hey @jeyvison 

I'm sorry for bothering you with this issue again, but a test discovered that the confirmation question for deleting Roles is still asserted against the old text value.
Therefore, I adjusted the value.

Could you please review this change?

Thank you and best regards,
István