### PR TITLE
[TECHNICAL-SUPPORT] LPS-87101

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -1086,10 +1086,11 @@ public class DDMDisplayContext {
 
 		List<DDMTemplate> results = _ddmTemplateService.search(
 			_ddmWebRequestHelper.getCompanyId(), groupIds,
-			getTemplateClassNameIds(), null, getResourceClassNameId(),
-			searchTerms.getKeywords(), searchTerms.getType(), getTemplateMode(),
-			searchTerms.getStatus(), templateSearch.getStart(),
-			templateSearch.getEnd(), templateSearch.getOrderByComparator());
+			getTemplateClassNameIds(), _getDDMTemplateClassPKs(),
+			getResourceClassNameId(), searchTerms.getKeywords(),
+			searchTerms.getType(), getTemplateMode(), searchTerms.getStatus(),
+			templateSearch.getStart(), templateSearch.getEnd(),
+			templateSearch.getOrderByComparator());
 
 		templateSearch.setResults(results);
 	}
@@ -1110,15 +1111,23 @@ public class DDMDisplayContext {
 
 		int total = _ddmTemplateService.searchCount(
 			_ddmWebRequestHelper.getCompanyId(), groupIds,
-			getTemplateClassNameIds(), null, getResourceClassNameId(),
-			searchTerms.getKeywords(), searchTerms.getType(), getTemplateMode(),
-			searchTerms.getStatus());
+			getTemplateClassNameIds(), _getDDMTemplateClassPKs(),
+			getResourceClassNameId(), searchTerms.getKeywords(),
+			searchTerms.getType(), getTemplateMode(), searchTerms.getStatus());
 
 		templateSearch.setTotal(total);
 	}
 
 	protected boolean showAncestorScopes() {
 		return ParamUtil.getBoolean(_renderRequest, "showAncestorScopes");
+	}
+
+	private long[] _getDDMTemplateClassPKs() {
+		if (getClassPK() > 0) {
+			return new long[] {getClassPK()};
+		}
+
+		return null;
 	}
 
 	private final DDMDisplayRegistry _ddmDisplayRegistry;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87101
https://issues.liferay.com/browse/LPP-31819

From @wanderlast:

> This issue and therefore the fix is not reproducible in master. However, the code is present in master and not deprecated and therefore this is getting sent here first. This is to correct a regression created by 82becf8ce18a77e91af9f2362d7442a57f82d400 which changes the classPK from the templateClassPK to null. With no classPK to filter by, the search results will show the same templates for any data definition that is a copy of another data definition. 
> 
> The original fix itself is to circumvent an issue related to SQLServer where the max # of parameters could be exceeded by the query generated by this code. This is due to its previous reference, as can be seen in the commit, to ddmDisplay.getTemplateClassPKs() which can be seen below:
> 
> 
> ```
> 		if (classPK > 0) {
> 			return new long[] {classPK};
> 		}
> 
> 		List<Long> classPKs = new ArrayList<>();
> 
> 		classPKs.add(0L);
> 
> 		List<DDMStructure> structures =
> 			DDMStructureLocalServiceUtil.getClassStructures(
> 				companyId, PortalUtil.getClassNameId(getStructureType()));
> 
> 		for (DDMStructure structure : structures) {
> 			classPKs.add(structure.getPrimaryKey());
> 		}
> 
> 		return ArrayUtil.toLongArray(classPKs);
> ```
> 
> As can be seen in this code, it attempts to grab all structures which results in the issue seen in LPS-85380. While this fix does technically reintroduce a class PK back into the search arguments, it does not cause the issue to occur again since it returns null if no class PK is found (similar to the fix in LPS-85380) instead of trying to grab all structures. This is identical to the fix that was added for the other commit in LPS-85380: fbf1ecfb7c163280df97d1954ab6fb52849ce7b7
> 
> Please let me know if you have any questions. Thanks!