### PR TITLE
LPS-88190 Form field validation not working for element sets

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java
@@ -268,6 +268,17 @@ public class DDMExpressionEvaluatorVisitor
 
 		Object variableValue = _variables.get(variable);
 
+		if ((variableValue == null) && (_variables.size() > 1)) {
+			for (Map.Entry<String, Object> entry : _variables.entrySet()) {
+				String key = entry.getKey();
+				Object value = entry.getValue();
+
+				if (key.startsWith(variable) && (value != null)) {
+					variableValue = value;
+				}
+			}
+		}
+
 		if ((variableValue == null) &&
 			_ddmExpressionFieldAccessor.isField(variable)) {
 


### PR DESCRIPTION
Hey @jeyvison 

Could you please review this pull request?

The issue is that in https://github.com/jeyvison/liferay-portal/blob/master/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java#L264 `variableValue == null` if the field was added through an element set.
Although `variableValue` is not present in `_variables`, and entry with the key variable<elementsetcode> will be present in the map, with the value entered by the user.
I solved the issue reported by the customer by assigning the value of the element set entry to `variableValue`.

Please let me know what you think of this. 

Thank you and best regards,
István