### PR TITLE
[TECHNICAL SUPPORT] LPS-87996 If selected layout was deleted, getSiblingLayoutsJSON request returns a 404 error. In this case, call _requestInitialLayouts and get initial layout list.

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -2320,6 +2320,15 @@ AUI.add(
 								themeDisplay.getPathMain() + '/portal/get_layouts',
 								{
 									after: {
+										failure: function() {
+											var bodyNode = instance._modal.bodyNode;
+
+											var listNode = bodyNode.one('.lfr-ddm-pages-container');
+
+											listNode.addClass('top-ended');
+
+											instance._requestInitialLayouts(0, groupId, privateLayout, instance._renderLayouts);
+										},
 										success: function() {
 											var	response = JSON.parse(this.get('responseData'));
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87996