### PR TITLE
LPS-88995 DDM upgrade to 7.1 fails with NPE due to DDMContent table's stats being locked

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/internal/DDMFormValuesJSONDeserializer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-io/src/main/java/com/liferay/dynamic/data/mapping/io/internal/DDMFormValuesJSONDeserializer.java
@@ -26,7 +26,6 @@ import com.liferay.dynamic.data.mapping.model.Value;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -88,9 +87,9 @@ public class DDMFormValuesJSONDeserializer
 				jsonObject.getJSONArray("fieldValues"), ddmForm, ddmFormValues);
 			setDDMFormLocalizedValuesDefaultLocale(ddmFormValues);
 		}
-		catch (JSONException jsone) {
+		catch (Exception e) {
 			if (_log.isWarnEnabled()) {
-				_log.warn(jsone, jsone);
+				_log.warn(e, e);
 			}
 		}
 


### PR DESCRIPTION
Hey @jeyvison 

Could you please review this pull request?

The issue is very similar to LPS-88790 but it is not the same. Instead of DDMStructure, this issue regards the DDMContent.
Moreover, it is reproducible not only on 7.1.x but on master too. Therefore, I send the pull request to master.

Thank you and best regards,
István