### PR TITLE
[TECHNICAL-SUPPORT] LPS-89444

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/numeric/numeric_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/numeric/numeric_field.js
@@ -81,7 +81,6 @@ AUI.add(
 
 						var numberMask = DDMNumeric.createNumberMask(numberMaskOptions);
 
-						instance.lastDataType = dataType;
 						instance.maskedInputController = DDMNumeric.vanillaTextMask(
 							{
 								inputElement: fieldNode.getDOM(),
@@ -147,10 +146,6 @@ AUI.add(
 
 						var fieldNode = instance.getInputNode();
 						var fieldSidebar = A.one('.' + CSS_SETTINGS_SIDEBAR + ' .liferay-ddm-form-field-numeric');
-
-						if (instance.maskedInputController && (instance.get('dataType') == instance.lastDataType)) {
-							return;
-						}
 
 						if (instance.maskedInputController && fieldSidebar) {
 							fieldNode = fieldSidebar.one('input');


### PR DESCRIPTION
/cc @brianikim 

Notes from Brian:
>https://issues.liferay.com/browse/LPS-89444
>
> The issue here is that additional/duplicate Numerical Fields are permitting alphabetical characters rather than only allowing numerical characters.
> 
> The reason for this issue is that for additional/duplicate Numerical Fields, the check run here: [link](https://github.com/liferay/liferay-portal/blob/ea96bc2b49a04790ce4e662a7a98b244ebc43cc3/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/numeric/numeric_field.js#L151-L153) prevents [applyMask](https://github.com/liferay/liferay-portal/blob/ea96bc2b49a04790ce4e662a7a98b244ebc43cc3/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/numeric/numeric_field.js#L66-L93) from being called which is the method that enforces the numerical rule of the field.
> 
> The solution here is simple in that we need to remove the unnecessary check being done because the rule enforcing should be done regardless of whether the fields are of the same type.
> 
> Please let me know if you have any questions. Thanks.
> 
> Sincerely,
> Brian Kim