### PR TITLE
LPS-90581 set empty value when it is not a number

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/main/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionEvaluatorVisitor.java
@@ -50,6 +50,7 @@ import com.liferay.dynamic.data.mapping.expression.internal.parser.DDMExpression
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -106,9 +107,14 @@ public class DDMExpressionEvaluatorVisitor
 		@NotNull DivisionExpressionContext context) {
 
 		BigDecimal bigDecimal1 = visitChild(context, 0);
+
 		BigDecimal bigDecimal2 = visitChild(context, 2);
 
-		return bigDecimal1.divide(bigDecimal2);
+		if (bigDecimal2.compareTo(BigDecimal.ZERO) == 0) {
+			return "NaN";
+		}
+
+		return bigDecimal1.divide(bigDecimal2, 2, RoundingMode.FLOOR);
 	}
 
 	@Override

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/test/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImplTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-expression/src/test/java/com/liferay/dynamic/data/mapping/expression/internal/DDMExpressionImplTest.java
@@ -82,7 +82,8 @@ public class DDMExpressionImplTest extends PowerMockito {
 		DDMExpressionImpl<BigDecimal> ddmExpression = createDDMExpression(
 			"6 / 3");
 
-		Assert.assertEquals(new BigDecimal(2), ddmExpression.evaluate());
+		Assert.assertEquals(
+			new BigDecimal(2).setScale(2), ddmExpression.evaluate());
 	}
 
 	@Test
@@ -90,7 +91,8 @@ public class DDMExpressionImplTest extends PowerMockito {
 		DDMExpressionImpl<BigDecimal> ddmExpression = createDDMExpression(
 			"15 / 2");
 
-		Assert.assertEquals(new BigDecimal(7.5), ddmExpression.evaluate());
+		Assert.assertEquals(
+			new BigDecimal(7.5).setScale(2), ddmExpression.evaluate());
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -377,7 +379,8 @@ public class DDMExpressionImplTest extends PowerMockito {
 		DDMExpressionImpl<BigDecimal> ddmExpression = createDDMExpression(
 			"(8 + 2) / 2.5");
 
-		Assert.assertEquals(new BigDecimal(4), ddmExpression.evaluate());
+		Assert.assertEquals(
+			new BigDecimal(4).setScale(2), ddmExpression.evaluate());
 	}
 
 	@Test

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/numeric/internal/NumericDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/numeric/internal/NumericDDMFormFieldTemplateContextContributor.java
@@ -31,6 +31,7 @@ import java.text.DecimalFormatSymbols;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -86,7 +87,12 @@ public class NumericDDMFormFieldTemplateContextContributor
 		String value = HtmlUtil.extractText(
 			ddmFormFieldRenderingContext.getValue());
 
-		parameters.put("value", getFormattedValue(value, locale));
+		if (Objects.equals(value, "NaN")) {
+			parameters.put("value", "");
+		}
+		else {
+			parameters.put("value", getFormattedValue(value, locale));
+		}
 
 		return parameters;
 	}


### PR DESCRIPTION
Hi @jeyvison , in this fix I'm setting to empty the field value when the calculated result is not a number. I'm not sure if it is the best approach, maybe we should define some warning to show to the user on this kind of situation. Let me know what you think.
Thanks!