### PR TITLE
[TECHNICAL-SUPPORT] LPS-83936

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -657,10 +657,14 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
+						var form = instance.getForm();
+
+						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+
 						var inputNode = instance.getInputNode();
 
 						if (inputNode) {
-							inputNode.attr('disabled', instance.get('readOnly'));
+							inputNode.attr('disabled', readOnly);
 						}
 
 						var container = instance.get('container');
@@ -669,13 +673,13 @@ AUI.add(
 							var selectorInput = container.one('.selector-input');
 
 							if (selectorInput) {
-								selectorInput.attr('disabled', instance.get('readOnly'));
+								selectorInput.attr('disabled', readOnly);
 							}
 
 							var checkboxInput = container.one('input[type="checkbox"]');
 
 							if (checkboxInput) {
-								checkboxInput.attr('disabled', instance.get('readOnly'));
+								checkboxInput.attr('disabled', readOnly);
 							}
 
 							var disableCheckboxInput = container.one('input[type="checkbox"][name$="disable"]');
@@ -1240,20 +1244,24 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
+						var form = instance.getForm();
+
+						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+
 						var container = instance.get('container');
 
 						var selectButtonNode = container.one('#' + instance.getInputName() + 'SelectButton');
 
-						selectButtonNode.attr('disabled', instance.get('readOnly'));
+						selectButtonNode.attr('disabled', readOnly);
 
 						var clearButtonNode = container.one('#' + instance.getInputName() + 'ClearButton');
 
-						clearButtonNode.attr('disabled', instance.get('readOnly'));
+						clearButtonNode.attr('disabled', readOnly);
 
 						var altNode = container.one('#' + instance.getInputName() + 'Alt');
 
 						if (altNode) {
-							altNode.set('readOnly', instance.get('readOnly'));
+							altNode.set('readOnly', readOnly);
 						}
 					},
 
@@ -1417,15 +1425,19 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
+						var form = instance.getForm();
+
+						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+
 						var container = instance.get('container');
 
 						var selectButtonNode = container.one('#' + instance.getInputName() + 'SelectButton');
 
-						selectButtonNode.attr('disabled', instance.get('readOnly'));
+						selectButtonNode.attr('disabled', readOnly);
 
 						var clearButtonNode = container.one('#' + instance.getInputName() + 'ClearButton');
 
-						clearButtonNode.attr('disabled', instance.get('readOnly'));
+						clearButtonNode.attr('disabled', readOnly);
 					},
 
 					_handleButtonsClick: function(event) {
@@ -1622,15 +1634,19 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
+						var form = instance.getForm();
+
+						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+
 						var container = instance.get('container');
 
 						var selectButtonNode = container.one('#' + instance.getInputName() + 'SelectButton');
 
-						selectButtonNode.attr('disabled', instance.get('readOnly'));
+						selectButtonNode.attr('disabled', readOnly);
 
 						var clearButtonNode = container.one('#' + instance.getInputName() + 'ClearButton');
 
-						clearButtonNode.attr('disabled', instance.get('readOnly'));
+						clearButtonNode.attr('disabled', readOnly);
 					},
 
 					_addBreadcrumbElement: function(label, layoutId, groupId, privateLayout) {
@@ -2818,7 +2834,9 @@ AUI.add(
 						instance.readOnlyLabel.html(instance.getLabelNode().getHTML());
 						instance.readOnlyText.html('<p>' + instance.getValue() + '</p>');
 
-						var readOnly = instance.get('readOnly');
+						var form = instance.getForm();
+
+						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
 
 						instance.readOnlyLabel.toggle(readOnly);
 						instance.readOnlyText.toggle(readOnly);
@@ -2912,9 +2930,13 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
+						var form = instance.getForm();
+
+						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+
 						var radioNodes = instance.getRadioNodes();
 
-						radioNodes.attr('disabled', instance.get('readOnly'));
+						radioNodes.attr('disabled', readOnly);
 					}
 				}
 			}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -185,6 +185,22 @@ AUI.add(
 				return root || instance;
 			},
 
+			getReadOnly: function() {
+				var instance = this;
+
+				if (instance.get('readOnly')) {
+					return true;
+				}
+
+				var form = instance.getForm();
+
+				if (!instance.get('localizable') && form.getDefaultLocale() != instance.get('displayLocale')) {
+					return true;
+				}
+
+				return false;
+			},
+
 			_getField: function(fieldNode) {
 				var instance = this;
 
@@ -657,9 +673,7 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
-						var form = instance.getForm();
-
-						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+						var readOnly = instance.getReadOnly();
 
 						var inputNode = instance.getInputNode();
 
@@ -1244,9 +1258,7 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
-						var form = instance.getForm();
-
-						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+						var readOnly = instance.getReadOnly();
 
 						var container = instance.get('container');
 
@@ -1425,9 +1437,7 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
-						var form = instance.getForm();
-
-						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+						var readOnly = instance.getReadOnly();
 
 						var container = instance.get('container');
 
@@ -1634,9 +1644,7 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
-						var form = instance.getForm();
-
-						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+						var readOnly = instance.getReadOnly();
 
 						var container = instance.get('container');
 
@@ -2834,9 +2842,7 @@ AUI.add(
 						instance.readOnlyLabel.html(instance.getLabelNode().getHTML());
 						instance.readOnlyText.html('<p>' + instance.getValue() + '</p>');
 
-						var form = instance.getForm();
-
-						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+						var readOnly = instance.getReadOnly();
 
 						instance.readOnlyLabel.toggle(readOnly);
 						instance.readOnlyText.toggle(readOnly);
@@ -2930,9 +2936,7 @@ AUI.add(
 					syncReadOnlyUI: function() {
 						var instance = this;
 
-						var form = instance.getForm();
-
-						var readOnly = instance.get('readOnly') || (!instance.get('localizable') && instance.get('displayLocale') != form.getDefaultLocale());
+						var readOnly = instance.getReadOnly();
 
 						var radioNodes = instance.getRadioNodes();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ChangeList.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ChangeList.macro
@@ -20,8 +20,8 @@ definition {
 		);
 	}
 
-	macro enableChangeList {
-		Check.checkToggleSwitch(
+	macro disableChangeList {
+		Uncheck.uncheckToggleSwitch(
 			locator1 = "ChangeListSettings#CHANGE_LISTS_TOGGLE_SWITCH"
 		);
 
@@ -35,8 +35,8 @@ definition {
 		Alert.viewSuccessMessage();
 	}
 
-	macro disableChangeList {
-		Uncheck.uncheckToggleSwitch(
+	macro enableChangeList {
+		Check.checkToggleSwitch(
 			locator1 = "ChangeListSettings#CHANGE_LISTS_TOGGLE_SWITCH"
 		);
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ChangeList.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ChangeList.macro
@@ -25,7 +25,12 @@ definition {
 			locator1 = "ChangeListSettings#CHANGE_LISTS_TOGGLE_SWITCH"
 		);
 
-		Click(locator1 = "Button#SAVE");
+		if (isSet(gotoOverview)) {
+			Click(locator1 = "ChangeListSettings#SAVE_AND_GO_TO_OVERVIEW_BUTTON");
+		}
+		else {
+			Click(locator1 = "Button#SAVE");
+		}
 
 		Alert.viewSuccessMessage();
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/changelist/ChangeListSettings.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/changelist/ChangeListSettings.path
@@ -19,6 +19,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>SAVE_AND_GO_TO_OVERVIEW_BUTTON</td>
+	<td>//button[contains(.,'Save and Go to Overview')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>SUPPORTED_CONTENT_TYPES</td>
 	<td>//span[contains(@data-title,'${key_changeListContentType}')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/changelist/ChangeListConfiguration.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/changelist/ChangeListConfiguration.testcase
@@ -36,6 +36,35 @@ definition {
 		AssertElementPresent(locator1 = "ChangeListSettings#DISABLED_SAVE_AND_GO_TO_OVERVIEW_BUTTON");
 	}
 
+	@description = "Enable Change List and go to Overview"
+	@priority = "5"
+	test EnableChangeListAndGoToOverview {
+		ProductMenu.gotoPortlet(
+			category = "Change Lists",
+			panel = "Control Panel",
+			portlet = "Settings"
+		);
+
+		ChangeList.enableChangeList(
+			gotoOverview = "true"
+		);
+
+		AssertTextEquals(
+			locator1 = "ChangeList#OVERVIEW_PAGE_TITLE",
+			value1 = "Select Change List"
+		);
+
+		ProductMenu.gotoPortlet(
+			category = "Change Lists",
+			panel = "Control Panel",
+			portlet = "Settings"
+		);
+
+		ChangeList.disableChangeList();
+
+		AssertElementPresent(locator1 = "ChangeListSettings#DISABLED_SAVE_AND_GO_TO_OVERVIEW_BUTTON");
+	}
+
 	@description = "Check Supported Content Types"
 	@priority = "4"
 	test CheckSupportedContentTypes {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -1065,7 +1065,7 @@ definition {
 
 	@priority = "5"
 	test StagingOnlyApprovedPublishToLive {
-		property portal.acceptance = "false";
+		property portal.acceptance = "true";
 		property testray.component.names = "Training";
 
 		ProductMenu.gotoSite(site = "Site Name");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/staging/usecase/Staging.testcase
@@ -1002,7 +1002,7 @@ definition {
 
 	@priority = "5"
 	test StagingMultipleDM {
-		property portal.acceptance = "false";
+		property portal.acceptance = "true";
 		property testray.component.names = "Training";
 
 		Navigator.gotoSitePage(pageName = "Staging Test Page", siteName = "Site Name");


### PR DESCRIPTION
/cc @Alec-Shay 

Notes from Alec:

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-33093
> https://issues.liferay.com/browse/LPS-83936
> 
> Non-localizable fields in content can be edited even when the localization is changed to one other than the default. This is problematic because a user may not realize the fields are not localizable, and so unintentionally overwrite the default translation, since really only the default can be changed.
> 
> This appears to have been caused by [LPS-78974](https://issues.liferay.com/browse/LPS-78974), which seems to have removed the code checking for this without replacement: https://github.com/liferay/liferay-portal-ee/commit/ef87aa31108f5350c55c4c6f382ab246b2e88307#diff-31faafccfa051120833493e5350865abL915
> 
> This fix simply adds back in a check (for each time a field is evaluated for `readOnly`) to also consider whether the field is not localizable and the currently viewed localization is not default.
> 
> Please let me know if there are any problems or concerns with this. Thank you.