### PR TITLE
LPS-66882 Import process fails when LAR references a DDM structure that has a default locale that is no longer enabled

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -52,6 +52,7 @@ import com.liferay.dynamic.data.mapping.util.DDM;
 import com.liferay.dynamic.data.mapping.util.DDMXML;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidator;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
@@ -2211,7 +2212,9 @@ public class DDMStructureLocalServiceImpl
 		throws PortalException {
 
 		try {
-			validate(nameMap, ddmForm.getDefaultLocale());
+			if (!ExportImportThreadLocal.isImportInProcess()) {
+				validate(nameMap, ddmForm.getDefaultLocale());
+			}
 
 			validate(ddmForm);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/test/DDMStructureStagedModelDataHandlerTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/test/DDMStructureStagedModelDataHandlerTest.java
@@ -33,12 +33,15 @@ import com.liferay.dynamic.data.mapping.test.util.DDMFormTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMFormValuesTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.util.DDMFormFactory;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
@@ -49,12 +52,15 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.registry.Registry;
 import com.liferay.registry.RegistryUtil;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -79,7 +85,71 @@ public class DDMStructureStagedModelDataHandlerTest
 	public void setUp() throws Exception {
 		super.setUp();
 
+		_availableLocales = LanguageUtil.getAvailableLocales(
+			TestPropsValues.getCompanyId());
+		_defaultLocale = LocaleUtil.getDefault();
+
 		setUpDDMDataProvider();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		LanguageUtil.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			TestPropsValues.getCompanyId(), _availableLocales, _defaultLocale);
+	}
+
+	@Test
+	public void testImportStructureWithDisabledDefaultLocale()
+		throws Exception {
+
+		DDMStructure structure = DDMStructureTestUtil.addStructure(
+			stagingGroup.getGroupId(), _CLASS_NAME);
+
+		Locale newLocale = LocaleUtil.BRAZIL;
+
+		if (newLocale.equals(_defaultLocale)) {
+			newLocale = LocaleUtil.CHINA;
+		}
+
+		LanguageUtil.init();
+
+		CompanyTestUtil.resetCompanyLocales(
+			stagingGroup.getCompanyId(), Arrays.asList(newLocale), newLocale);
+
+		initExport();
+
+		try {
+			ExportImportThreadLocal.setPortletExportInProcess(true);
+
+			StagedModelDataHandlerUtil.exportStagedModel(
+				portletDataContext, structure);
+		}
+		finally {
+			ExportImportThreadLocal.setPortletExportInProcess(false);
+		}
+
+		initImport();
+
+		StagedModel exportedStagedModel = readExportedStagedModel(structure);
+
+		Assert.assertNotNull(exportedStagedModel);
+
+		try {
+			ExportImportThreadLocal.setPortletImportInProcess(true);
+
+			StagedModelDataHandlerUtil.importStagedModel(
+				portletDataContext, exportedStagedModel);
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
+
+		StagedModel importedStagedModel = getStagedModel(
+			exportedStagedModel.getUuid(), liveGroup);
+
+		Assert.assertNotNull(importedStagedModel);
 	}
 
 	@Test
@@ -433,6 +503,9 @@ public class DDMStructureStagedModelDataHandlerTest
 
 	private static final String _CLASS_NAME =
 		"com.liferay.dynamic.data.lists.model.DDLRecordSet";
+
+	private static Set<Locale> _availableLocales;
+	private static Locale _defaultLocale;
 
 	private DDMDataProvider _ddmDataProvider;
 


### PR DESCRIPTION
Hello @jeyvison, 

I've taken up a pull request solution by Michael Bowerman for an LPS that was closed, then reopened, and that's now affecting a customer in 7.1. 

The approach to the solution was discussed in the link referenced here https://github.com/rafaprax/liferay-portal/pull/103#issuecomment-232691452. 

Please let me know if you have any questions. Thanks!