### PR TITLE
[TECHNICAL SUPPORT] LPS-91149

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DefaultDDMFormFieldTypeSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/DefaultDDMFormFieldTypeSettings.java
@@ -22,7 +22,6 @@ import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutPage;
 import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutRow;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidation;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
-import com.liferay.petra.string.StringPool;
 
 /**
  * @author Marcellus Tavares
@@ -72,8 +71,8 @@ public interface DefaultDDMFormFieldTypeSettings
 
 	@DDMFormField(
 		label = "%searchable", optionLabels = {"%disable", "%keyword"},
-		optionValues = {StringPool.BLANK, "keyword"},
-		predefinedValue = "keyword", type = "radio"
+		optionValues = {"none", "keyword"}, predefinedValue = "keyword",
+		type = "radio"
 	)
 	public String indexType();
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/editor/internal/EditorDDMFormFieldTypeSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/editor/internal/EditorDDMFormFieldTypeSettings.java
@@ -22,7 +22,6 @@ import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutPage;
 import com.liferay.dynamic.data.mapping.annotations.DDMFormLayoutRow;
 import com.liferay.dynamic.data.mapping.form.field.type.DefaultDDMFormFieldTypeSettings;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
-import com.liferay.petra.string.StringPool;
 
 /**
  * @author Bruno Basto
@@ -69,8 +68,8 @@ public interface EditorDDMFormFieldTypeSettings
 
 	@DDMFormField(
 		label = "%searchable", optionLabels = {"%disable", "%keyword", "%text"},
-		optionValues = {StringPool.BLANK, "keyword", "text"},
-		predefinedValue = "keyword", type = "radio"
+		optionValues = {"none", "keyword", "text"}, predefinedValue = "keyword",
+		type = "radio"
 	)
 	@Override
 	public String indexType();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/text/internal/TextDDMFormFieldTypeSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/text/internal/TextDDMFormFieldTypeSettings.java
@@ -25,7 +25,6 @@ import com.liferay.dynamic.data.mapping.form.field.type.DefaultDDMFormFieldTypeS
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldOptions;
 import com.liferay.dynamic.data.mapping.model.DDMFormFieldValidation;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
-import com.liferay.petra.string.StringPool;
 
 /**
  * @author Lino Alves
@@ -133,8 +132,8 @@ public interface TextDDMFormFieldTypeSettings
 
 	@DDMFormField(
 		label = "%searchable", optionLabels = {"%disable", "%keyword", "%text"},
-		optionValues = {StringPool.BLANK, "keyword", "text"},
-		predefinedValue = "keyword", type = "radio"
+		optionValues = {"none", "keyword", "text"}, predefinedValue = "keyword",
+		type = "radio"
 	)
 	@Override
 	public String indexType();

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/util/DDMIndexerImpl.java
@@ -78,7 +78,7 @@ public class DDMIndexerImpl implements DDMIndexer {
 				String indexType = ddmStructure.getFieldProperty(
 					field.getName(), "indexType");
 
-				if (Validator.isNull(indexType)) {
+				if (Validator.isNull(indexType) || indexType.equals("none")) {
 					continue;
 				}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/DDMStructureLocalServiceTest.java
@@ -877,7 +877,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 	public void testValidateIndexTypePropertyValue2() throws Exception {
 		DDMForm ddmForm = DDMFormTestUtil.createDDMForm("Field1");
 
-		DDMFormTestUtil.setIndexTypeProperty(ddmForm, StringPool.BLANK);
+		DDMFormTestUtil.setIndexTypeProperty(ddmForm, "none");
 
 		DDMStructure structure = ddmStructureTestHelper.addStructure(
 			ddmForm, StorageType.JSON.getValue());
@@ -891,8 +891,7 @@ public class DDMStructureLocalServiceTest extends BaseDDMServiceTestCase {
 
 		DDMFormField textFieldAfterUpdate = ddmFormFieldAfterUpdate.get(0);
 
-		Assert.assertEquals(
-			StringPool.BLANK, textFieldAfterUpdate.getIndexType());
+		Assert.assertEquals("none", textFieldAfterUpdate.getIndexType());
 	}
 
 	@Test(expected = InvalidParentStructureException.class)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
@@ -363,7 +363,7 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 	}
 
 	private static final String[] _DDM_FORM_FIELD_INDEX_TYPES = {
-		StringPool.BLANK, "keyword", "text"
+		StringPool.BLANK, "none", "keyword", "text"
 	};
 
 	private static final Pattern _ddmFormFieldNamePattern = Pattern.compile(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-91149

[LPS-90362](https://issues.liferay.com/browse/LPS-90362) (sent in https://github.com/jeyvison/liferay-portal/pull/217) causes a regression:
> "Disable" searchable option is reset to "Keyword" after reopening "properties" tab.
> Data is correctly stored to database, but in case you reopen the field properties tab, radio button is reset to "Keyword".

Root cause of the issue is:

1. In case of setting indexType to disabled, it is saved successfully and it internally stores a empty string "".
2. If you edit again a field with indexType="", the forms UI resets indexType value to "keyword" because at javascript level (radio.soy.js) the empty "" is replaced by the predefinedValue, as it is considered a undefined value.

In order to solve this, I have restore previous solution, storing "none" for that kind of fields, and in order to avoid breaking webcontent logic (that was the original issue in LPS-90362), I have extended _DDM_FORM_FIELD_INDEX_TYPES values, see: https://github.com/jeyvison/liferay-portal/pull/264/commits/ca490eb9072f6c22420944e713f854360851fc31

So, we will have for indexType following values:
- Only forms => "none"
- Only webcontent => ""
- Both => "keyword" and "text"

In my opinion, changing webcontent indexType code from "" to "none" it is a bit risky, so it is better to maintain both

/cc: @linolaoj
