### PR TITLE
[TECHNICAL-SUPPORT] LPS-93204 importing edited default structure creates duplicate default structure

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
@@ -38,6 +38,7 @@ import com.liferay.dynamic.data.mapping.service.DDMDataProviderInstanceLinkLocal
 import com.liferay.dynamic.data.mapping.service.DDMDataProviderInstanceLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLayoutLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMStructureVersionLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
@@ -705,6 +706,34 @@ public class DDMStructureStagedModelDataHandler
 		return false;
 	}
 
+	protected boolean isPreloadedStructure(
+		long defaultUserId, DDMStructure structure) {
+
+		if (defaultUserId == structure.getUserId()) {
+			return true;
+		}
+
+		DDMStructureVersion ddmStructureVersion = null;
+
+		try {
+			ddmStructureVersion =
+				_ddmStructureVersionLocalService.getStructureVersion(
+					structure.getStructureId(),
+					DDMStructureConstants.VERSION_DEFAULT);
+		}
+		catch (PortalException pe) {
+			_log.error(pe, pe);
+		}
+
+		if ((ddmStructureVersion != null) &&
+			(defaultUserId == ddmStructureVersion.getUserId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	@Reference(unbind = "-")
 	protected void setDDMFormDeserializerTracker(
 		DDMFormDeserializerTracker ddmFormDeserializerTracker) {
@@ -731,6 +760,13 @@ public class DDMStructureStagedModelDataHandler
 		DDMStructureLocalService ddmStructureLocalService) {
 
 		_ddmStructureLocalService = ddmStructureLocalService;
+	}
+
+	@Reference(unbind = "-")
+	protected void setDDMStructureVersionLocalService(
+		DDMStructureVersionLocalService ddmStructureVersionLocalService) {
+
+		_ddmStructureVersionLocalService = ddmStructureVersionLocalService;
 	}
 
 	@Reference(unbind = "-")
@@ -762,6 +798,7 @@ public class DDMStructureStagedModelDataHandler
 	private DDMFormLayoutDeserializerTracker _ddmFormLayoutDeserializerTracker;
 	private DDMStructureLayoutLocalService _ddmStructureLayoutLocalService;
 	private DDMStructureLocalService _ddmStructureLocalService;
+	private DDMStructureVersionLocalService _ddmStructureVersionLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMStructureStagedModelDataHandler.java
@@ -156,11 +156,7 @@ public class DDMStructureStagedModelDataHandler
 			return referenceAttributes;
 		}
 
-		boolean preloaded = false;
-
-		if (defaultUserId == structure.getUserId()) {
-			preloaded = true;
-		}
+		boolean preloaded = isPreloadedStructure(defaultUserId, structure);
 
 		referenceAttributes.put("preloaded", String.valueOf(preloaded));
 
@@ -228,7 +224,7 @@ public class DDMStructureStagedModelDataHandler
 		long defaultUserId = _userLocalService.getDefaultUserId(
 			structure.getCompanyId());
 
-		if (defaultUserId == structure.getUserId()) {
+		if (isPreloadedStructure(defaultUserId, structure)) {
 			structureElement.addAttribute("preloaded", "true");
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
@@ -17,9 +17,12 @@ package com.liferay.dynamic.data.mapping.web.internal.exportimport.data.handler;
 import com.liferay.dynamic.data.mapping.constants.DDMPortletKeys;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.model.DDMTemplateConstants;
+import com.liferay.dynamic.data.mapping.model.DDMTemplateVersion;
 import com.liferay.dynamic.data.mapping.security.permission.DDMPermissionSupport;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
+import com.liferay.dynamic.data.mapping.service.DDMTemplateVersionLocalService;
 import com.liferay.dynamic.data.mapping.web.internal.exportimport.content.processor.DDMTemplateExportImportContentProcessor;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
@@ -547,6 +550,34 @@ public class DDMTemplateStagedModelDataHandler
 			template.getResourceClassName());
 	}
 
+	protected boolean isPreloadedTemplate(
+		long defaultUserId, DDMTemplate template) {
+
+		if (defaultUserId == template.getUserId()) {
+			return true;
+		}
+
+		DDMTemplateVersion ddmTemplateVersion = null;
+
+		try {
+			ddmTemplateVersion =
+				_ddmTemplateVersionLocalService.getTemplateVersion(
+					template.getTemplateId(),
+					DDMTemplateConstants.VERSION_DEFAULT);
+		}
+		catch (PortalException pe) {
+			_log.error(pe, pe);
+		}
+
+		if ((ddmTemplateVersion != null) &&
+			(defaultUserId == ddmTemplateVersion.getUserId())) {
+
+			return true;
+		}
+
+		return false;
+	}
+
 	@Reference(unbind = "-")
 	protected void setDDMStructureLocalService(
 		DDMStructureLocalService ddmStructureLocalService) {
@@ -571,6 +602,13 @@ public class DDMTemplateStagedModelDataHandler
 	}
 
 	@Reference(unbind = "-")
+	protected void setDDMTemplateVersionLocalService(
+		DDMTemplateVersionLocalService ddmTemplateVersionLocalService) {
+
+		_ddmTemplateVersionLocalService = ddmTemplateVersionLocalService;
+	}
+
+	@Reference(unbind = "-")
 	protected void setImageLocalService(ImageLocalService imageLocalService) {
 		_imageLocalService = imageLocalService;
 	}
@@ -590,6 +628,7 @@ public class DDMTemplateStagedModelDataHandler
 	private DDMTemplateExportImportContentProcessor
 		_ddmTemplateExportImportContentProcessor;
 	private DDMTemplateLocalService _ddmTemplateLocalService;
+	private DDMTemplateVersionLocalService _ddmTemplateVersionLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
@@ -138,11 +138,7 @@ public class DDMTemplateStagedModelDataHandler
 			return referenceAttributes;
 		}
 
-		boolean preloaded = false;
-
-		if (defaultUserId == template.getUserId()) {
-			preloaded = true;
-		}
+		boolean preloaded = isPreloadedTemplate(defaultUserId, template);
 
 		referenceAttributes.put("preloaded", String.valueOf(preloaded));
 
@@ -264,7 +260,7 @@ public class DDMTemplateStagedModelDataHandler
 		long defaultUserId = _userLocalService.getDefaultUserId(
 			template.getCompanyId());
 
-		if (defaultUserId == template.getUserId()) {
+		if (isPreloadedTemplate(defaultUserId, template)) {
 			templateElement.addAttribute("preloaded", "true");
 		}
 


### PR DESCRIPTION
Hi @jeyvison ,

This is an export/import related bug.
We mark contents which are created by default as "preloaded", as the UUIDs don't match between environments.
This fix ensures that the default Structure/Template is still considered as preloaded, even if it was edited.
Previously we created a similar fix for [Web Contents](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java#L1136-L1153).

Notes from the previous pull request:

Relevant tickets:

https://issues.liferay.com/browse/LPP-33464
https://issues.liferay.com/browse/LPS-93204
https://issues.liferay.com/browse/PTR-766 (for prior discussion)

Notes from @brianikim:

> The issue here is that:
> 

> > Importing web content to a new environment creates a duplicate default structure if the structure was "edited" in the initial environment.

> 
> The PTR associated with LPS-93204 has concluded that the behavior is not intended and should fixed in such a way so that:
> 
> > About the export/import related issue:
> > If I understand it correctly, the problem is that the default Web Content Structure is not considered as "preloaded", because it was edited.
> > This seems wrong to me, we should check the first version's userId as we do it for Web Contents, and consider the default structure "preloaded".
> 
> The fix checks whether the default web content structure and web content template have been edited. If they have been edited, their ids will be used to fetch the original versions of the two and use the userId of the original versions to be compared with the defaultUserId.
> 

