### PR TITLE
[TECHNICAL SUPPORT] LPS-94545

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/display/context/DDMFormDisplayContext.java
@@ -254,11 +254,22 @@ public class DDMFormDisplayContext {
 	}
 
 	public String getDefaultLanguageId() throws PortalException {
+		String languageId = ParamUtil.getString(_renderRequest, "languageId");
+
+		Locale locale = LocaleUtil.fromLanguageId(languageId, true, false);
+
 		DDMForm ddmForm = getDDMForm();
 
-		return ParamUtil.getString(
-			_renderRequest, "languageId",
-			LanguageUtil.getLanguageId(ddmForm.getDefaultLocale()));
+		Set<Locale> availableLocales = ddmForm.getAvailableLocales();
+
+		if (!availableLocales.contains(locale)) {
+			HttpServletRequest request = PortalUtil.getHttpServletRequest(
+				_renderRequest);
+
+			locale = getLocale(request, ddmForm);
+		}
+
+		return LanguageUtil.getLanguageId(locale);
 	}
 
 	public DDMFormInstance getFormInstance() {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-94545

When a form is added to a page, languageId parameter is always empty and getDefaultLanguageId() returns the default locale of ddmForm, so title and description is displayed in that language and forms fields are displayed in the correct one returned by getLocale(request, ddmForm)

To avoid this issue, with this change in case languageId parameter is empty or invalid, we fallback to existing getLocale(request, ddmForm) method that internally handles correct behavior.