### PR TITLE
Add new parameter to the html taglib

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/liferay-ddm.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/liferay-ddm.xml
@@ -36,6 +36,12 @@
 				<required>false</required>
 			</attribute>
 			<attribute>
+				<name>defaultLocale</name>
+				<inputType>java.util.Locale</inputType>
+				<outputType>java.util.Locale</outputType>
+				<required>false</required>
+			</attribute>
+			<attribute>
 				<name>documentLibrarySelectorURL</name>
 				<inputType>java.lang.String</inputType>
 				<outputType>java.lang.String</outputType>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/base/BaseHTMLTag.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/java/com/liferay/dynamic/data/mapping/taglib/servlet/taglib/base/BaseHTMLTag.java
@@ -53,6 +53,10 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		return _defaultEditLocale;
 	}
 
+	public java.util.Locale getDefaultLocale() {
+		return _defaultLocale;
+	}
+
 	public java.lang.String getDocumentLibrarySelectorURL() {
 		return _documentLibrarySelectorURL;
 	}
@@ -117,6 +121,10 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		_defaultEditLocale = defaultEditLocale;
 	}
 
+	public void setDefaultLocale(java.util.Locale defaultLocale) {
+		_defaultLocale = defaultLocale;
+	}
+
 	public void setDocumentLibrarySelectorURL(java.lang.String documentLibrarySelectorURL) {
 		_documentLibrarySelectorURL = documentLibrarySelectorURL;
 	}
@@ -177,6 +185,7 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		_classPK = 0;
 		_ddmFormValues = null;
 		_defaultEditLocale = null;
+		_defaultLocale = null;
 		_documentLibrarySelectorURL = null;
 		_fieldsNamespace = null;
 		_groupId = 0;
@@ -202,6 +211,7 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 		setNamespacedAttribute(request, "classPK", _classPK);
 		setNamespacedAttribute(request, "ddmFormValues", _ddmFormValues);
 		setNamespacedAttribute(request, "defaultEditLocale", _defaultEditLocale);
+		setNamespacedAttribute(request, "defaultLocale", _defaultLocale);
 		setNamespacedAttribute(request, "documentLibrarySelectorURL", _documentLibrarySelectorURL);
 		setNamespacedAttribute(request, "fieldsNamespace", _fieldsNamespace);
 		setNamespacedAttribute(request, "groupId", _groupId);
@@ -225,6 +235,7 @@ public abstract class BaseHTMLTag extends com.liferay.taglib.util.IncludeTag {
 	private long _classPK = 0;
 	private com.liferay.dynamic.data.mapping.storage.DDMFormValues _ddmFormValues = null;
 	private java.util.Locale _defaultEditLocale = null;
+	private java.util.Locale _defaultLocale = null;
 	private java.lang.String _documentLibrarySelectorURL = null;
 	private java.lang.String _fieldsNamespace = null;
 	private long _groupId = 0;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/init.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/init.jsp
@@ -24,6 +24,7 @@ long classNameId = GetterUtil.getLong(String.valueOf(request.getAttribute("lifer
 long classPK = GetterUtil.getLong(String.valueOf(request.getAttribute("liferay-ddm:html:classPK")));
 com.liferay.dynamic.data.mapping.storage.DDMFormValues ddmFormValues = (com.liferay.dynamic.data.mapping.storage.DDMFormValues)request.getAttribute("liferay-ddm:html:ddmFormValues");
 java.util.Locale defaultEditLocale = (java.util.Locale)request.getAttribute("liferay-ddm:html:defaultEditLocale");
+java.util.Locale defaultLocale = (java.util.Locale)request.getAttribute("liferay-ddm:html:defaultLocale");
 java.lang.String documentLibrarySelectorURL = GetterUtil.getString((java.lang.String)request.getAttribute("liferay-ddm:html:documentLibrarySelectorURL"));
 java.lang.String fieldsNamespace = GetterUtil.getString((java.lang.String)request.getAttribute("liferay-ddm:html:fieldsNamespace"));
 long groupId = GetterUtil.getLong(String.valueOf(request.getAttribute("liferay-ddm:html:groupId")));

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -23,9 +23,7 @@
 			<%
 			List<String> languageIds = new ArrayList<String>();
 
-			Locale defaultLocale = defaultEditLocale;
-
-			String defaultLanguageId = LocaleUtil.toLanguageId(defaultLocale);
+			String defaultLanguageId = LocaleUtil.toLanguageId(defaultEditLocale);
 
 			languageIds.add(defaultLanguageId);
 
@@ -125,7 +123,7 @@
 
 			var ddmFormDefinition = <%= DDMUtil.getDDMFormJSONString(ddmForm) %>;
 
-			ddmFormDefinition.defaultLanguageId = '<%= defaultLanguageId %>';
+			ddmFormDefinition.defaultLanguageId = '<%= LocaleUtil.toLanguageId(defaultLocale) %>';
 
 			var liferayDDMForm = Liferay.component(
 				'<portlet:namespace /><%= HtmlUtil.escapeJS(fieldsNamespace) %>ddmForm',

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/html/start.jsp
@@ -21,11 +21,7 @@
 		<div class="input-group-item input-group-item-shrink input-localized-content <%= hideClass %>" role="menu" style="justify-content: flex-end;">
 
 			<%
-			List<String> languageIds = new ArrayList<String>();
-
 			String defaultLanguageId = LocaleUtil.toLanguageId(defaultEditLocale);
-
-			languageIds.add(defaultLanguageId);
 
 			Set<Locale> availableLocales = LanguageUtil.getAvailableLocales(groupId);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/liferay-ddm.tld
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-taglib/src/main/resources/META-INF/resources/liferay-ddm.tld
@@ -39,6 +39,12 @@
 			<type>java.util.Locale</type>
 		</attribute>
 		<attribute>
+			<name>defaultLocale</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>java.util.Locale</type>
+		</attribute>
+		<attribute>
 			<name>documentLibrarySelectorURL</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>


### PR DESCRIPTION
Hey,

In this PR I have added a new parameter to the html taglib for setting the defaultLocale of the structure

Right now, there is only one parameter `defaultEditLocale` which changes both the language is shown and the default language of the structure. In our use case in Web content we need to be able to show a different language for the structure, but without changing the default language.

Any comments/suggestions will be appreciated :)

Thanks

