### PR TITLE
[TS] LPS-81915

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
@@ -234,10 +234,6 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 				ddmFormDefaultLocale);
 
 			validateOptionalDDMFormFieldLocalizedProperty(
-				ddmFormField, "predefinedValue", ddmFormAvailableLocales,
-				ddmFormDefaultLocale);
-
-			validateOptionalDDMFormFieldLocalizedProperty(
 				ddmFormField, "tip", ddmFormAvailableLocales,
 				ddmFormDefaultLocale);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-81915

From @Alec-Shay: 

> If a web content structure has more than one available translation, then default values for that article cannot be added without having all of the same translations. This prevents users from using any behaviors that would update the default values, since the validation will fail and an error will be thrown (which looks generic in the UI).
> 
> We have two use cases that this validation gets in the way of for users:
> 
> If a user tries to save the 'default content' by clicking "Edit Default Values" for a structure that has more than one translation, then the user cannot actually save it until they initialize all of the same translations the structure has (which is inconvenient, for one, but also can be very confusing since there is no indication of this on the edit screen, or of which translations are still needed).
> 
> If a user upgrades from a version of Liferay (e.g., 6.2) before this validation was added, they may have some default values that do not meet this criteria. Upon upgrading to 7.1, then, the user can no longer edit or import this content because of this validation.
> 
> Both of these seem to be significantly damaging to user experience, and may be difficult to implement workarounds for. Tthe first case may require either changing the frontend to dynamically take care of all of this, or at least adding a new feature to include some cues to the UI. The second case, meanwhile, may require running an UpgradeProcess or script to populate the missing translations, which could prove to be difficult, since it seems we would have to implement a new and reliable way to edit the translations for articles from the Java code.
> 
> Because of this, we concluded that the best solution may just be to remove this validation. We could not find a good reason for why this validation really exists in the first place (it seems to have been added with https://issues.liferay.com/browse/LPS-46899, but there was no explanation for why), so we think it may be more beneficial for it not to be there. In any case, the content still seems to work if it is allowed to be saved/imported without all of the translations.
> 
> That said, if there are any issues this that we may have overlooked, or perhaps an alternative solution we have not considered that may be better, please let us know. Any feedback would be appreciated. Thanks.