### PR TITLE
[TECHNICAL SUPPORT] LPS-98519 Prepend path context in case URI starts with slash and it is missing

### DIFF
--- a/modules/apps/frontend-js/frontend-js-jquery-web/src/main/java/com/liferay/frontend/js/jquery/web/internal/servlet/taglib/JQueryTopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-jquery-web/src/main/java/com/liferay/frontend/js/jquery/web/internal/servlet/taglib/JQueryTopHeadDynamicInclude.java
@@ -75,8 +75,8 @@ public class JQueryTopHeadDynamicInclude extends BaseDynamicInclude {
 			sb.append("<script data-senna-track=\"permanent\" src=\"");
 			sb.append(
 				_portal.getStaticResourceURL(
-					httpServletRequest, _portal.getPathContext() + "/combo",
-					"minifierType=js", _lastModified));
+					httpServletRequest, "/combo", "minifierType=js",
+					_lastModified));
 
 			for (String fileName : _FILE_NAMES) {
 				sb.append("&");

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -5283,7 +5283,13 @@ public class PortalImpl implements Portal {
 			parameterMap = HttpUtil.getParameterMap(queryString);
 		}
 
-		StringBundler sb = new StringBundler(17);
+		StringBundler sb = new StringBundler(18);
+
+		if (uri.startsWith(StringPool.FORWARD_SLASH) &&
+			!uri.startsWith(getPathContext())) {
+
+			sb.append(getPathContext());
+		}
 
 		// URI
 


### PR DESCRIPTION
Brian Chan rejected first pr, see: https://github.com/brianchandotcom/liferay-portal/pull/76236#issuecomment-515627026

I have implemented an alternative solution, changing only `PortalImpl.getStaticResourceURL(...)` code