### PR TITLE
Lps 98527 matt

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -493,34 +493,6 @@ AUI.add(
 					instance.get('container').remove();
 				},
 
-				addLocaleToLocalizationMap: function(locale) {
-					var instance = this;
-
-					var localizationMap = instance.get('localizationMap');
-
-					if (Lang.isUndefined(localizationMap[locale])) {
-						var predefinedValue = instance.getPredefinedValueByLocale(
-							locale
-						);
-
-						if (predefinedValue) {
-							localizationMap[locale] = predefinedValue;
-						} else {
-							var defaultLocale = instance.getDefaultLocale();
-
-							if (
-								defaultLocale &&
-								localizationMap[defaultLocale]
-							) {
-								localizationMap[locale] =
-									localizationMap[defaultLocale];
-							} else {
-								localizationMap[locale] = '';
-							}
-						}
-					}
-				},
-
 				createField: function(fieldTemplate) {
 					var instance = this;
 
@@ -543,6 +515,35 @@ AUI.add(
 					field.set('parent', parent);
 
 					return field;
+				},
+
+				getDefaultLocalization: function(locale) {
+					var instance = this;
+
+					var localizationMap = instance.get('localizationMap');
+
+					if (Lang.isUndefined(localizationMap[locale])) {
+						var predefinedValue = instance.getPredefinedValueByLocale(
+							locale
+						);
+
+						if (predefinedValue) {
+							return predefinedValue;
+						} else {
+							var defaultLocale = instance.getDefaultLocale();
+
+							if (
+								defaultLocale &&
+								localizationMap[defaultLocale]
+							) {
+								return localizationMap[defaultLocale];
+							} else {
+								return '';
+							}
+						}
+					} else {
+						return localizationMap[locale];
+					}
 				},
 
 				getFieldByNameInFieldDefinition: function(name) {
@@ -730,7 +731,6 @@ AUI.add(
 
 						var displayLocale = instance.get('displayLocale');
 
-						field.addLocaleToLocalizationMap(displayLocale);
 						field.set('displayLocale', displayLocale);
 
 						if (instance.originalField) {
@@ -875,7 +875,9 @@ AUI.add(
 						}
 
 						if (Lang.isUndefined(value)) {
-							value = instance.getValue();
+							value = instance.getDefaultLocalization(
+								instance.get('displayLocale')
+							);
 						}
 
 						instance.setValue(value);
@@ -924,11 +926,17 @@ AUI.add(
 					var instance = this;
 
 					var localizationMap = instance.get('localizationMap');
+					var defaultLocale = instance.getDefaultLocale();
 
 					var value = instance.getValue();
 
 					if (instance.get('localizable')) {
-						localizationMap[locale] = value;
+						if (
+							locale === defaultLocale ||
+							value !== localizationMap[defaultLocale]
+						) {
+							localizationMap[locale] = value;
+						}
 					} else {
 						localizationMap = value;
 					}
@@ -1034,7 +1042,6 @@ AUI.add(
 					var displayLocale = event.item.getAttribute('data-value');
 
 					instance.updateLocalizationMap(currentLocale);
-					instance.addLocaleToLocalizationMap(displayLocale);
 
 					instance.set('displayLocale', displayLocale);
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -684,6 +684,20 @@ AUI.add(
 					parser.parseContent(content);
 				},
 
+				populateRepeatedSiblings: function(locale) {
+					var instance = this;
+
+					var siblings = instance.getRepeatedSiblings();
+
+					siblings.forEach(function(item) {
+						var localizationMap = item.get('localizationMap');
+
+						if (Lang.isUndefined(localizationMap[locale])) {
+							localizationMap[locale] = '';
+						}
+					});
+				},
+
 				remove: function() {
 					var instance = this;
 
@@ -936,6 +950,8 @@ AUI.add(
 							value !== localizationMap[defaultLocale]
 						) {
 							localizationMap[locale] = value;
+
+							instance.populateRepeatedSiblings(locale);
 						}
 					} else {
 						localizationMap = value;


### PR DESCRIPTION
Notes from @Matthewchan1:

> https://issues.liferay.com/browse/LPS-98527
> 
> Issue:
> Customized fields for web content are becoming "dirtied", meaning they save language translations simply by switching between localizations.
> 
> Cause:
> In [_onLocaleChanged](https://github.com/liferay/liferay-portal/blob/d8129c6aa4b153c4fd7569ee080bf1612c977bb6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L1029), we are immediately adding new localizations to the localizationMap when they are first displayed. I think the problem is that we needed to delay adding localizations until the user manually enters a different value, which is read by [updateLocalizationMap](https://github.com/liferay/liferay-portal/blob/d8129c6aa4b153c4fd7569ee080bf1612c977bb6/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js#L922).
> 
> Fix:
> I just turned addLocaleToLocalizationMap into a getter so that localizations can be created at a later time, and used this getter to display the default translation in the user interface.
> 
> I also gave UpdateLocalizationMap a check to see if localized text no longer matches the default, which means the user has modified it.
> 
> Finally, to handle fields duplicated by the Repeatable setting, I added in an extra function populateRepeatedSiblings.
> 
> After the inclusion of this fix, web content locales will not save translations upon switching and instead follow the default localization until taking in user input.