### PR TITLE
LPS-104222 Fill in all empty locales before submission

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3922,6 +3922,8 @@ AUI.add(
 				_onSubmitForm() {
 					var instance = this;
 
+					instance.fillEmptyLocales();
+
 					instance.finalizeRepeatableFieldLocalizations();
 
 					instance.updateDDMFormInputValue();
@@ -4026,6 +4028,31 @@ AUI.add(
 					});
 
 					instance.repeatableInstances = null;
+				},
+
+				fillEmptyLocales() {
+					var instance = this;
+
+					instance.get('fields').forEach(field => {
+						if (!field.get('localizable')) {
+							return;
+						}
+
+						var localizationMap = field.get('localizationMap');
+
+						var defaultLocale = instance.getDefaultLocale();
+
+						instance.get('availableLanguageIds').forEach(locale => {
+							if (Object.keys(localizationMap).includes(locale)) {
+								return;
+							}
+
+							localizationMap[locale] =
+								localizationMap[defaultLocale];
+						});
+
+						field.set('localizationMap', localizationMap);
+					});
 				},
 
 				finalizeRepeatableFieldLocalizations() {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-104222
https://issues.liferay.com/browse/LPP-35461

**Problem:** [LPS-98527](https://issues.liferay.com/browse/LPS-98527) prevents the localizationMap from being updated during the editing of a JournalArticle to prevent unchanged locales from being "dirtied". This leads to the current ticket's problem where an unchanged fields' value is never saved on the frontend and causes ordering problems when the backend tries to fill end missing values.

**Solution:** Fill all empty field locales with the default value. This will save what the user sees. 