### PR TITLE
[TS] LPS-106505

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -4154,6 +4154,15 @@ AUI.add(
 						if (type === 'ddm-text-html') {
 							instance.recreateEditor(field);
 						}
+
+						if (fieldDefinition.nestedFields.length > 0) {
+							var nestedFields = fieldDefinition.nestedFields;
+							nestedFields.forEach(element => {
+								if (element.type === 'ddm-text-html') {
+									instance.recreateEditor(field);
+								}
+							});
+						}
 					}
 				},
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-35670
https://issues.liferay.com/browse/LPS-106505

From @wanderlast:

> This fix covers an edge case for the overall issue outlined in the body of the LPP. The LPP and the initial LPS (https://issues.liferay.com/browse/LPS-98228) addressed the issue that HTML fields using a CKEditor editors would lose their contents when dragged and dropped. However, CS reported that the client was using these HTML fields nested in other fields. This fix insures that the nested fields are also checked for HTML fields and that those fields are recreated as well.