### PR TITLE
[TS] LPS-112077 Audit portlet does not display user information from workflow activity

### DIFF
--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
@@ -16,8 +16,10 @@ package com.liferay.portal.workflow.task.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -72,6 +74,11 @@ public class CompleteTaskMVCActionCommand
 			WorkflowConstants.CONTEXT_USER_ID,
 			String.valueOf(themeDisplay.getUserId()));
 
+		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+			"serviceContext");
+
+		serviceContext.setRequest(_portal.getHttpServletRequest(actionRequest));
+
 		workflowTaskManager.completeWorkflowTask(
 			themeDisplay.getCompanyId(), themeDisplay.getUserId(),
 			workflowTaskId, transitionName, comment, workflowContext);
@@ -93,5 +100,8 @@ public class CompleteTaskMVCActionCommand
 
 		return workflowInstance.getWorkflowContext();
 	}
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/portal-impl/src/com/liferay/portal/workflow/UserWorkflowHandler.java
+++ b/portal-impl/src/com/liferay/portal/workflow/UserWorkflowHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.workflow;
 
+import com.liferay.portal.kernel.audit.AuditRequestThreadLocal;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
@@ -21,6 +22,7 @@ import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.spring.osgi.OSGiBeanProperties;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.workflow.BaseWorkflowHandler;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
@@ -28,6 +30,9 @@ import java.io.Serializable;
 
 import java.util.Locale;
 import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpSession;
 
 /**
  * @author Michael C. Han
@@ -69,10 +74,38 @@ public class UserWorkflowHandler extends BaseWorkflowHandler<User> {
 			(status == WorkflowConstants.STATUS_APPROVED)) {
 
 			UserLocalServiceUtil.completeUserRegistration(user, serviceContext);
+
+			_updateAudit(workflowContext);
 		}
 
 		return UserLocalServiceUtil.updateStatus(
 			userId, status, serviceContext);
+	}
+
+	private void _updateAudit(Map<String, Serializable> workflowContext) {
+		AuditRequestThreadLocal auditRequestThreadLocal =
+			AuditRequestThreadLocal.getAuditThreadLocal();
+
+		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
+			WorkflowConstants.CONTEXT_SERVICE_CONTEXT);
+
+		auditRequestThreadLocal.setClientIP(serviceContext.getRemoteAddr());
+		auditRequestThreadLocal.setClientHost(serviceContext.getRemoteHost());
+
+		auditRequestThreadLocal.setRealUserId(
+			Long.valueOf((String)workflowContext.get("userId")));
+
+		HttpServletRequest httpServletRequest =
+			PortalUtil.getOriginalServletRequest(serviceContext.getRequest());
+
+		auditRequestThreadLocal.setServerName(
+			httpServletRequest.getServerName());
+		auditRequestThreadLocal.setServerPort(
+			httpServletRequest.getServerPort());
+
+		HttpSession session = httpServletRequest.getSession();
+
+		auditRequestThreadLocal.setSessionID(session.getId());
 	}
 
 }


### PR DESCRIPTION
[LPS-112077](https://issues.liferay.com/browse/LPS-112077)

Hi @jeyvison ,

I am sending this to you, because the issue is workflow related. Please let me know if you think it should go to someone else.

In short, the issue is that AuditEvent records don't contain the approver data because AuditRequestThreadLocal is not populated properly.

Thank you,
Istvan