### PR TITLE
[TS] LPS-119116 | master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1098,6 +1098,9 @@ AUI.add(
 
 							instance.setValue(value);
 						}
+						else {
+							instance.setValue(instance.getValue());
+						}
 					}
 				},
 


### PR DESCRIPTION


**Description**:
When using a web content's structure with an Image field in its definition, if this field is configured as no-localizable, the Clear and Preview buttons will not be shown when a value is present in the field.
Same behavior happens when using a Documents and Media field: in this case only with Clear button because there is not Preview button.

**Steps to reproduce:**
1. Navigate to Content & Data -> Web Content -> Structure
2. Add a new structure containing an Image field and a Documents and Media field.
3. Configure both fields as not localizable.
4. Go back to the Web Content tab and add a new content based on that structure.
5. Select a file for each of the fields. Publish the web content.
6. Select the just created web content.

**Solution proposed:**
Setting the value of the field when it is not configured as localizable triggers the UI synchronization. Thus, Clear and Preview buttons are checked if the must be showed.

Best,
 Sergio.

References:
https://issues.liferay.com/browse/LPS-119116