### PR TITLE
Lps 119263

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/constants/DDMConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/constants/DDMConstants.java
@@ -32,4 +32,12 @@ public class DDMConstants {
 	public static final String SERVICE_NAME =
 		"com.liferay.dynamic.data.mapping";
 
+	public static final String[] SUPPORTED_DDM_FORM_FIELD_TYPES = {
+		"checkbox", "ddm-color", "ddm-date", "ddm-decimal",
+		"ddm-documentlibrary", "ddm-geolocation", "ddm-image", "ddm-integer",
+		"ddm-journal-article", "ddm-link-to-page", "ddm-number",
+		"ddm-paragraph", "ddm-separator", "ddm-text-html", "fieldset", "option",
+		"radio", "select", "text", "textarea"
+	};
+
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/validator/DDMFormValidationException.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/validator/DDMFormValidationException.java
@@ -313,6 +313,25 @@ public class DDMFormValidationException extends PortalException {
 
 	}
 
+	public static class MustSetValidTypeForFieldType
+		extends DDMFormValidationException {
+
+		public MustSetValidTypeForFieldType(String fieldType) {
+			super(
+				String.format(
+					"Invalid type entered for field type %s", fieldType));
+
+			_fieldType = fieldType;
+		}
+
+		public String getFieldType() {
+			return _fieldType;
+		}
+
+		private final String _fieldType;
+
+	}
+
 	public static class MustSetValidValidationExpression
 		extends MustSetValidDDMFormFieldExpression {
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/constants/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.5.0
+version 2.6.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/validator/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/validator/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/render/DDMFormFieldFreeMarkerRenderer.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dynamic.data.mapping.internal.render;
 
+import com.liferay.dynamic.data.mapping.constants.DDMConstants;
 import com.liferay.dynamic.data.mapping.constants.DDMPortletKeys;
 import com.liferay.dynamic.data.mapping.constants.DDMTemplateConstants;
 import com.liferay.dynamic.data.mapping.internal.util.DDMFormFieldFreeMarkerRendererUtil;
@@ -79,7 +80,7 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 
 	@Override
 	public String[] getSupportedDDMFormFieldTypes() {
-		return _SUPPORTED_DDM_FORM_FIELD_TYPES;
+		return DDMConstants.SUPPORTED_DDM_FORM_FIELD_TYPES;
 	}
 
 	@Override
@@ -720,14 +721,6 @@ public class DDMFormFieldFreeMarkerRenderer implements DDMFormFieldRenderer {
 	private static final String _DEFAULT_NAMESPACE = "alloy";
 
 	private static final String _DEFAULT_READ_ONLY_NAMESPACE = "readonly";
-
-	private static final String[] _SUPPORTED_DDM_FORM_FIELD_TYPES = {
-		"checkbox", "ddm-color", "ddm-date", "ddm-decimal",
-		"ddm-documentlibrary", "ddm-geolocation", "ddm-image", "ddm-integer",
-		"ddm-journal-article", "ddm-link-to-page", "ddm-number",
-		"ddm-paragraph", "ddm-separator", "ddm-text-html", "fieldset", "option",
-		"radio", "select", "text", "textarea"
-	};
 
 	private static final String _TPL_EXT = ".ftl";
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
@@ -41,6 +41,7 @@ import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.Mus
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidDefaultLocaleForProperty;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidFormRuleExpression;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidIndexType;
+import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidTypeForFieldType;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidValidationExpression;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidationException.MustSetValidVisibilityExpression;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValidator;
@@ -278,6 +279,20 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 			throw new MustSetFieldType(ddmFormField.getName());
 		}
 
+		Boolean validType = false;
+
+		for (String type : _SUPPORTED_DDM_FORM_FIELD_TYPES) {
+			if (type.equals(ddmFormField.getType())) {
+				validType = true;
+
+				break;
+			}
+		}
+
+		if (!validType) {
+			throw new MustSetValidTypeForFieldType(ddmFormField.getType());
+		}
+
 		Matcher matcher = _ddmFormFieldTypePattern.matcher(
 			ddmFormField.getType());
 
@@ -441,6 +456,14 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 
 	private static final String[] _DDM_FORM_FIELD_INDEX_TYPES = {
 		StringPool.BLANK, "keyword", "none", "text"
+	};
+
+	private static final String[] _SUPPORTED_DDM_FORM_FIELD_TYPES = {
+		"checkbox", "ddm-color", "ddm-date", "ddm-decimal",
+		"ddm-documentlibrary", "ddm-geolocation", "ddm-image", "ddm-integer",
+		"ddm-journal-article", "ddm-link-to-page", "ddm-number",
+		"ddm-paragraph", "ddm-separator", "ddm-text-html", "fieldset", "option",
+		"radio", "select", "text", "textarea"
 	};
 
 	private static final Pattern _ddmFormFieldNamePattern = Pattern.compile(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-validator/src/main/java/com/liferay/dynamic/data/mapping/validator/internal/DDMFormValidatorImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.dynamic.data.mapping.validator.internal;
 
+import com.liferay.dynamic.data.mapping.constants.DDMConstants;
 import com.liferay.dynamic.data.mapping.expression.CreateExpressionRequest;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionException;
 import com.liferay.dynamic.data.mapping.expression.DDMExpressionFactory;
@@ -281,7 +282,7 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 
 		Boolean validType = false;
 
-		for (String type : _SUPPORTED_DDM_FORM_FIELD_TYPES) {
+		for (String type : DDMConstants.SUPPORTED_DDM_FORM_FIELD_TYPES) {
 			if (type.equals(ddmFormField.getType())) {
 				validType = true;
 
@@ -456,14 +457,6 @@ public class DDMFormValidatorImpl implements DDMFormValidator {
 
 	private static final String[] _DDM_FORM_FIELD_INDEX_TYPES = {
 		StringPool.BLANK, "keyword", "none", "text"
-	};
-
-	private static final String[] _SUPPORTED_DDM_FORM_FIELD_TYPES = {
-		"checkbox", "ddm-color", "ddm-date", "ddm-decimal",
-		"ddm-documentlibrary", "ddm-geolocation", "ddm-image", "ddm-integer",
-		"ddm-journal-article", "ddm-link-to-page", "ddm-number",
-		"ddm-paragraph", "ddm-separator", "ddm-text-html", "fieldset", "option",
-		"radio", "select", "text", "textarea"
 	};
 
 	private static final Pattern _ddmFormFieldNamePattern = Pattern.compile(


### PR DESCRIPTION
Notes from @noornajj:
> https://issues.liferay.com/browse/LPS-119263
> 
> The issue here was that the validateDDMFormFieldType method did not validate whether the field type being added is one of the predefined types in DDMFormFieldType.
> To fix the issue, I added a check on whether the field type is one of the predefined types. If not, then I added a new DDMFormValidationException class, MustSetValidTypeForFieldType, that is thrown.