### PR TITLE
[TS] LPS-120559

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -629,7 +629,6 @@ public class JournalTransformer {
 					String optionLabel = localizedLabel.getString(locale);
 
 					templateNode.appendOptionMap(optionValue, optionLabel);
-
 					templateNode.appendOption(optionValue);
 				}
 			}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -629,7 +629,6 @@ public class JournalTransformer {
 					String optionLabel = localizedLabel.getString(locale);
 
 					templateNode.appendOptionMap(optionValue, optionLabel);
-					templateNode.appendOption(optionValue);
 				}
 			}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -41,7 +41,6 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -68,7 +67,7 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		put("data", data);
 		put("type", type);
 		put("options", new ArrayList<String>());
-		put("optionsMap", new HashMap<String, String>());
+		put("optionsMap", new LinkedHashMap<String, String>());
 	}
 
 	public void appendChild(TemplateNode templateNode) {


### PR DESCRIPTION
Hi @jeyvison,

This fix reverts a wrong previous solution (LPS-116559) regarding select fields which did not take into account those select fields with multiple assignation when the getOptions method is invoked. According to LPS-54235, getOptions must return the selected options while getOptionsMap should return the available options within an ordered key-value map.

Could you please review it?

Thanks in advance